### PR TITLE
UPSTREAM: <carry>: Don't panic on CSI migration timeout

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go
@@ -282,7 +282,10 @@ func initializeCSINode(host volume.VolumeHost) error {
 			// using CSI for all Migrated volume plugins. Then all the CSINode initialization
 			// code can be dropped from Kubelet.
 			// Kill the Kubelet process and allow it to restart to retry initialization
-			klog.Fatalf("Failed to initialize CSINodeInfo after retrying")
+			//klog.Fatalf("Failed to initialize CSINodeInfo after retrying")
+			// OCP: don't kill kubelet yet, see https://bugzilla.redhat.com/show_bug.cgi?id=1817382
+			klog.Errorf("Failed to initialize CSINodeInfo after retrying")
+			kvh.SetKubeletError(nil)
 		}
 	}()
 	return nil


### PR DESCRIPTION
Don't require CSINode annotation to be present before kubelet starts, because TLS bootstrap can take more than 60 seconds. OCP 4.5 does not support CSI migration yet, so it is safe to do.

Tracking real fix here: https://bugzilla.redhat.com/show_bug.cgi?id=1817382
